### PR TITLE
fix: remove `read_to_string_lossy` default impl

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,8 +2,19 @@ MIT License
 
 Copyright 2018-2024 the Deno authors
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -4,10 +4,8 @@ use std::borrow::Cow;
 use std::path::Path;
 
 pub trait DenoPkgJsonFs {
-  fn read_to_string_lossy(
-    &self,
-    path: &Path,
-  ) -> Result<String, std::io::Error>;
+  fn read_to_string_lossy(&self, path: &Path)
+    -> Result<String, std::io::Error>;
 }
 
 impl<'a> Default for &'a dyn DenoPkgJsonFs {

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -7,12 +7,7 @@ pub trait DenoPkgJsonFs {
   fn read_to_string_lossy(
     &self,
     path: &Path,
-  ) -> Result<String, std::io::Error> {
-    // allowed here for the real fs
-    #[allow(clippy::disallowed_methods)]
-    let bytes = std::fs::read(path)?;
-    Ok(string_from_utf8_lossy(bytes))
-  }
+  ) -> Result<String, std::io::Error>;
 }
 
 impl<'a> Default for &'a dyn DenoPkgJsonFs {


### PR DESCRIPTION
I accidentally added this when copying and pasting.