### PR TITLE
feat: parse 'private' field

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,9 @@ pub struct PackageJson {
   pub dev_dependencies: Option<IndexMap<String, String>>,
   pub scripts: Option<IndexMap<String, String>>,
   pub workspaces: Option<Vec<String>>,
+
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub private: Option<bool>,
 }
 
 impl PackageJson {
@@ -131,6 +134,7 @@ impl PackageJson {
         dev_dependencies: None,
         scripts: None,
         workspaces: None,
+        private: None,
       });
     }
 
@@ -160,6 +164,13 @@ impl PackageJson {
         Some(result)
       } else {
         None
+      }
+    }
+
+    fn map_bool(value: serde_json::Value) -> Option<bool> {
+      match value {
+        Value::Bool(v) => Some(v),
+        _ => None,
       }
     }
 
@@ -222,6 +233,7 @@ impl PackageJson {
     let name = name_val.and_then(map_string);
     let version = version_val.and_then(map_string);
     let module = module_val.and_then(map_string);
+    let private = package_json.remove("private").and_then(map_bool);
 
     let dependencies = package_json
       .remove("dependencies")
@@ -272,6 +284,7 @@ impl PackageJson {
       dev_dependencies,
       scripts,
       workspaces,
+      private,
     }
   }
 
@@ -582,6 +595,42 @@ mod test {
     let json_value = serde_json::json!({
       "name": "test",
       "version": "1",
+      "exports": {
+        ".": "./main.js",
+      },
+      "bin": "./main.js",
+      "types": "./types.d.ts",
+      "imports": {
+        "#test": "./main.js",
+      },
+      "main": "./main.js",
+      "module": "./module.js",
+      "type": "module",
+      "dependencies": {
+        "name": "1.2",
+      },
+      "devDependencies": {
+        "name": "1.2",
+      },
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1",
+      },
+      "workspaces": ["asdf", "asdf2"]
+    });
+    let package_json = PackageJson::load_from_value(
+      PathBuf::from("/package.json"),
+      json_value.clone(),
+    );
+    let serialized_value = serde_json::to_value(&package_json).unwrap();
+    assert_eq!(serialized_value, json_value);
+  }
+
+  #[test]
+  fn test_deserialize_serialize_2() {
+    let json_value = serde_json::json!({
+      "name": "test",
+      "version": "1",
+      "private": true,
       "exports": {
         ".": "./main.js",
       },


### PR DESCRIPTION
This PR enables parsing the `private` field in `package.json` files, this can be useful to improve how TypeScript "binary" scripts are handled by Deno when accessed via NPM packages ( https://github.com/denoland/deno/issues/24862 ) .