### PR TITLE
fix: implement Debug on PackageJsonCache

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ pub type PackageJsonDepsRc = crate::sync::MaybeArc<PackageJsonDeps>;
 #[allow(clippy::disallowed_types)]
 type PackageJsonDepsRcCell = crate::sync::MaybeOnceLock<PackageJsonDepsRc>;
 
-pub trait PackageJsonCache {
+pub trait PackageJsonCache: std::fmt::Debug {
   fn get(&self, path: &Path) -> Option<PackageJsonRc>;
   fn set(&self, path: PathBuf, package_json: PackageJsonRc);
 }


### PR DESCRIPTION
So that this can be attached to structs that implement Debug.